### PR TITLE
Update repo name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Speech to Text Browser Application
 
-[![Build Status](https://travis-ci.org/watson-developer-cloud/speech-to-text-nodejs.svg?branch=master)](https://travis-ci.org/watson-developer-cloud/speech-to-text-nodejs)
+[![Build Status](https://travis-ci.org/IBM/language-translation-ui.svg?branch=master)](https://travis-ci.org/IBM/language-translation-ui)
 
   The [Speech to Text][service_url] service uses IBM's speech recognition capabilities to convert speech in multiple languages into text. The transcription of incoming audio is continuously sent back to the client with minimal delay, and it is corrected as more speech is heard. The service is accessed via a WebSocket interface; a REST HTTP interface is also available.
 
@@ -8,7 +8,7 @@ Node.js is also used to provide the browser client's authentication token.
 
 Give it a try! Click the button below to fork into IBM DevOps Services and deploy your own copy of this application on Bluemix.
 
-[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/watson-developer-cloud/speech-to-text-nodejs)
+[![Deploy to Bluemix](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM/language-translation-ui)
 
 ## Getting Started
 


### PR DESCRIPTION
This repo was forked from watson-developer-cloud/speech-to-text-nodejs.
Update the README with the new name.